### PR TITLE
Add variable means to plot legend

### DIFF
--- a/gfdlvitals/plot.py
+++ b/gfdlvitals/plot.py
@@ -41,6 +41,7 @@ def plot_timeseries(
     nyears=None,
     labels=None,
     legend=True,
+    means=True,
 ):
     """Standardized function to make a timeseries plot
 
@@ -62,6 +63,8 @@ def plot_timeseries(
         Comma-separated list of dataset labels, by default None
     legend : bool, optional
         Display a legend for the plot, by default True
+    means : bool, optional
+        Add variable means to the legend, by default True
 
     Returns
     -------
@@ -143,13 +146,21 @@ def plot_timeseries(
             nc_time_axis.CalendarDateTime(item, "noleap") for item in dset.index.values
         ]
 
+        # Add means to the labels
+        _label = labels[i]
+        if means:
+            _mean = float(dset[var].values[0:nyears].mean())
+            _mean = round(_mean, 4)
+            _label = f"{_label}  (mean={_mean})"
+            labels[i] = _label
+
         # Make the first plot
         (axes_dict[label]["line"],) = _ax.plot(
             times[0:nyears],
             dset[var].values[0:nyears],
             color=dset.attrs["color"],
             alpha=dset.attrs["alpha"],
-            label=labels[i],
+            label=_label,
         )
 
         _lines.append(axes_dict[label]["line"])


### PR DESCRIPTION
This PR adds functionality to list the variable mean values in the plot legend.

This feature was requested by @LoriTSentman.  Lori - here is an example plot.  Is this what you envisioned?

![mean_annotation](https://user-images.githubusercontent.com/6594675/154164496-f883c575-ffeb-4f0c-a90f-5e408a57c4a4.png)

