### PR TITLE
Pad missing data with null values

### DIFF
--- a/gfdlvitals/extensions.py
+++ b/gfdlvitals/extensions.py
@@ -498,7 +498,7 @@ class Timeseries:
         self.dict = dict(zip(self._t, self._data))
         self.dict = {
             **self.dict,
-            **dict(zip(missing_times, [np.nan for x in missing_times])),
+            **dict(zip(missing_times, [np.nan] * len(missing_times))),
         }
 
     @property


### PR DESCRIPTION
- Prevents a hard failure when constructing the
  VitalsDataFrame object when the variables in the
  sqlite file contain different lengths

Closes #18 #10 