### PR TITLE
Fixed issue when weights field has missing values

### DIFF
--- a/gfdlvitals/util/xrtools.py
+++ b/gfdlvitals/util/xrtools.py
@@ -86,6 +86,9 @@ def xr_weighted_avg(dset, weights):
             if sorted(dset[x].dims) == sorted(weight.dims):
                 _dset[x] = dset[x]
 
+        if isinstance(weight, xr.DataArray):
+            weight = weight.fillna(0.0)
+
         _dset_weighted = _dset.weighted(weight).mean()
         for x in list(_dset_weighted.variables):
             _dset_weighted[x] = _dset_weighted[x].astype(dset[x].dtype)


### PR DESCRIPTION
- In xrtools, the weighting function did not check for the condition of missing values in the weights field. If weights are a DataArray type, this patch fills the missing values with zeros before calling the weighted average