### PR TITLE
Fixes scalar_axis issue in extract_ocean_scalar.py

### DIFF
--- a/gfdlvitals/util/extract_ocean_scalar.py
+++ b/gfdlvitals/util/extract_ocean_scalar.py
@@ -19,18 +19,21 @@ def mom6(fdata, fyear, outdir, outname="globalAveOcean.db"):
         Path to output directory
     """
 
-    ignore_list = ["time_bounds", "time_bnds", "average_T2", "average_T1", "average_DT"]
+    ignore_list = ["time_bounds", "time_bnds", "average_T2", "average_T1", "average_DT", "nv"]
 
     var_dict = fdata.variables.keys()
     var_dict = list(set(var_dict) - set(ignore_list))
 
     for varname in var_dict:
-        if len(fdata.variables[varname].shape) == 2:
+        if len(fdata.variables[varname].shape) <= 2:
             units = gmeantools.extract_metadata(fdata, varname, "units")
             long_name = gmeantools.extract_metadata(fdata, varname, "long_name")
             result = fdata.variables[varname]
             if result.shape[0] == 12:
-                result = result[:, 0]
+                if len(result.shape) == 2:
+                    result = result[:, 0]
+                else:
+                    result = result[:]
                 result = np.ma.average(
                     result,
                     weights=[
@@ -50,7 +53,10 @@ def mom6(fdata, fyear, outdir, outname="globalAveOcean.db"):
                     axis=0,
                 )
             elif result.shape[0] == 1:
-                result = result[0, 0]
+                if len(result.shape) == 2:
+                    result = result[0, 0]
+                else:
+                    result = result[0]
             sqlfile = f"{outdir}/{fyear}.{outname}"
             gmeantools.write_metadata(sqlfile, varname, "units", units)
             gmeantools.write_metadata(sqlfile, varname, "long_name", long_name)

--- a/gfdlvitals/util/xrtools.py
+++ b/gfdlvitals/util/xrtools.py
@@ -88,7 +88,7 @@ def xr_weighted_avg(dset, weights):
 
         if isinstance(weight, xr.DataArray):
             weight = weight.fillna(0.0)
-                  ï
+
         _dset_weighted = _dset.weighted(weight).mean()
         for x in list(_dset_weighted.variables):
             _dset_weighted[x] = _dset_weighted[x].astype(dset[x].dtype)

--- a/gfdlvitals/util/xrtools.py
+++ b/gfdlvitals/util/xrtools.py
@@ -86,6 +86,9 @@ def xr_weighted_avg(dset, weights):
             if sorted(dset[x].dims) == sorted(weight.dims):
                 _dset[x] = dset[x]
 
+        if isinstance(weight, xr.DataArray):
+            weight = weight.fillna(0.0)
+                  ï
         _dset_weighted = _dset.weighted(weight).mean()
         for x in list(_dset_weighted.variables):
             _dset_weighted[x] = _dset_weighted[x].astype(dset[x].dtype)


### PR DESCRIPTION
Addresses #37 by accommodating ocean_scalar_annual variables of either dimension size 2 (i.e. with scalar_axis) or dimension size (i.e. without scalar_axis)