### PR TITLE
Remove the use of `average_DT`

### DIFF
--- a/gfdlvitals/averagers/cubesphere.py
+++ b/gfdlvitals/averagers/cubesphere.py
@@ -62,7 +62,9 @@ def xr_average(fyear, tar, modules):
                 _masked_area.sum().data,
             )
 
-            weights = dset.average_DT.astype("float") * _masked_area
+            t_bounds = dset.time_bnds
+            dt = t_bounds[:,:,1] - t_bounds[:,:,0]
+            weights = dt.astype("float") * _masked_area
             _dset_weighted = xrtools.xr_weighted_avg(dset, weights)
             xrtools.xr_to_db(
                 _dset_weighted, fyear, f"{fyear}.{region}Ave{modules[member]}.db"

--- a/gfdlvitals/averagers/ice.py
+++ b/gfdlvitals/averagers/ice.py
@@ -136,7 +136,10 @@ def xr_average(fyear, tar, modules):
             newvars = {x: x + "_min" for x in list(_dset_min.variables)}
             _dset_min = _dset_min.rename(newvars)
 
-            weights = dset.average_DT.astype("float")
+            t_bounds = dset.time_bnds
+            dt = t_bounds[:,:,1] - t_bounds[:,:,0]
+            weights = dt.astype("float")
+
             _dset_weighted = xrtools.xr_weighted_avg(_dset, weights)
             newvars = {x: x + "_mean" for x in list(_dset_weighted.variables)}
             _dset_weighted = _dset_weighted.rename(newvars)

--- a/gfdlvitals/averagers/land_lm4.py
+++ b/gfdlvitals/averagers/land_lm4.py
@@ -111,7 +111,9 @@ def xr_average(fyear, tar, modules):
 
                 # _masked_area = _masked_area.fillna(0)
 
-                weights = dset.average_DT.astype("float") * _masked_area
+                t_bounds = dset.time_bnds
+                dt = t_bounds[:,:,1] - t_bounds[:,:,0]
+                weights = dt.astype("float") * _masked_area
                 if _measure == "soil_area":
                     area_x_depth = _masked_area * depth
                     gmeantools.write_sqlite_data(

--- a/gfdlvitals/averagers/latlon.py
+++ b/gfdlvitals/averagers/latlon.py
@@ -57,7 +57,9 @@ def xr_average(fyear, tar, modules):
                 _masked_area.sum().data,
             )
 
-            weights = dset.average_DT.astype("float") * _masked_area
+            t_bounds = dset.time_bnds
+            dt = t_bounds[:,:,1] - t_bounds[:,:,0]
+            weights = dt.astype("float") * _masked_area
             _dset_weighted = xrtools.xr_weighted_avg(dset, weights)
             xrtools.xr_to_db(
                 _dset_weighted, fyear, f"{fyear}.{region}Ave{modules[member]}.db"

--- a/gfdlvitals/averagers/tripolar.py
+++ b/gfdlvitals/averagers/tripolar.py
@@ -62,7 +62,9 @@ def xr_average(fyear, tar, modules):
                 _masked_area.sum().data,
             )
 
-            weights = dset.average_DT.astype("float") * _masked_area
+            t_bounds = dset.time_bnds
+            dt = t_bounds[:,:,1] - t_bounds[:,:,0]
+            weights = dt.astype("float") * _masked_area
             _dset_weighted = xrtools.xr_weighted_avg(dset, weights)
             xrtools.xr_to_db(
                 _dset_weighted, fyear, f"{fyear}.{region}Ave{modules[member]}.db"


### PR DESCRIPTION
As described in #36, the new diag manager no longer writes out the `average_T1` , `average_T2`, and `average_DT` variables. There are places in this code that use `average_DT`.

This PR address this issue by removing the use of `average_DT`, instead the `time_bnd` variable is used to calculate the `average_DT` by taking the difference between the start/end period for each time. 

Because the old diag manager is always writing `time_bnds` this update will still work for both the new and the old diag manager. 

